### PR TITLE
Enable tracking of multiple branches

### DIFF
--- a/billsourcery.go
+++ b/billsourcery.go
@@ -43,9 +43,11 @@ func main() {
 	app.Command("timestats-image", "Provide stats over time about the source code in a png/jpg/svg", func(cmd *cli.Cmd) {
 		cacheDB := cmd.StringOpt("cache-db", os.Getenv("HOME")+"/.billsourcery_timestats_cache", "timestats cache")
 		notBefore := cmd.StringOpt("earliest", "c7937fbe95bbef245d627dccad0dfc4baad35b7c", "Do not include data from before this revision")
+		branchesCs := cmd.StringOpt("branches", "master", "which branches to cover (comma separated, no spaces")
 		output := cmd.StringOpt("output", "/tmp/billtimestats.png", "output graph for stats over time")
 		cmd.Action = func() {
-			doProcessAll(*sourceRoot, newTimeStatsImageProcessor(*cacheDB, *notBefore, *output))
+			branches := strings.Split(*branchesCs, ",")
+			doProcessAll(*sourceRoot, newTimeStatsImageProcessor(*cacheDB, *notBefore, branches, *output))
 		}
 	})
 


### PR DESCRIPTION
`timestats-image` now supports a `branches` option, allowing multiple
branches to be specified to appear on the graph.  This allows showing
how different things on master (which represents live bill) and
MASTER-BILL (which represents the obvious) are from each other.